### PR TITLE
**Updated:** .vsix Manifest file to allow Extension to be compatible with VS 2019.

### DIFF
--- a/RecordConstructorGenerator/RecordConstructorGenerator/RecordConstructorGenerator.Vsix/source.extension.vsixmanifest
+++ b/RecordConstructorGenerator/RecordConstructorGenerator/RecordConstructorGenerator.Vsix/source.extension.vsixmanifest
@@ -20,7 +20,7 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="RecordConstructorGenerator" Path="|RecordConstructorGenerator|"/>
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.Compiler" Version="[15.0,16.0)" DisplayName="Roslyn Language Services" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.Compiler" Version="[15.0,17.0)" DisplayName="Roslyn Language Services" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
I've had a look into this one and I believe these changes should allow the Extension to work with Visual Studio 2019.

Original issue: [Issue #8 - VS 2019 Support](https://github.com/ufcpp/RecordConstructorGenerator/issues/8)

This involved a minor update to the Manifest file which updates the Version Range for the following prerequisites:

'**Microsoft.VisualStudio.Component.CoreEditor**'
'**Microsoft.VisualStudio.Component.Roslyn.Compiler**'

Hope this helps!